### PR TITLE
fix: update builder to golang:1.24-trixie

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@ ARG CONTAINER_VERSION=13.3
 # ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
 # │ STAGE 1: Build pgweb from source                                         │
 # ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
-FROM golang:1.23-bookworm AS builder
+FROM golang:1.24-trixie AS builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git jq curl \


### PR DESCRIPTION
Updates builder image to resolve Go 1.24 dependency. References #13